### PR TITLE
Update to azure-storage-blob v12

### DIFF
--- a/sas_blob_utils.py
+++ b/sas_blob_utils.py
@@ -31,7 +31,7 @@ from azure.core.exceptions import ResourceNotFoundError
 
 
 class SasBlob:
-    """SAS URI: https://<account>.blob.windows.net/<container>?<sas_token>"""
+    """SAS URI: https://<account>.blob.core.windows.net/<container>?<sas_token>"""
     @staticmethod
     def _get_resource_reference(prefix: str) -> str:
         return '{}{}'.format(prefix, str(uuid.uuid4()).replace('-', ''))
@@ -166,7 +166,7 @@ class SasBlob:
 
         account = SasBlob.get_account_from_uri(sas_uri)
         container = SasBlob.get_container_from_uri(sas_uri)
-        container_url = f'https://{account}.blob.windows.net/{container}'
+        container_url = f'https://{account}.blob.core.windows.net/{container}'
         container_client = ContainerClient.from_container_url(
             container_url, credential=SasBlob.get_sas_key_from_uri(sas_uri))
 
@@ -246,7 +246,7 @@ class SasBlob:
         Raises: azure.core.exceptions.ResourceExistsError, if container already
             exists
         """
-        account_url = f'https://{account_name}.blob.windows.net'
+        account_url = f'https://{account_name}.blob.core.windows.net'
         container_client = ContainerClient(account_url=account_url,
                                            container_name=container_name,
                                            credential=account_key)
@@ -312,8 +312,8 @@ class SasBlob:
         container_name = SasBlob.get_container_from_uri(container_sas_uri)
         sas_token = SasBlob.get_sas_key_from_uri(container_sas_uri)
 
-        account_url = f'https://{account_name}.blob.windows.net'
+        account_url = f'https://{account_name}.blob.core.windows.net'
         blob_uri = f'{account_url}/{container_name}/{blob_name}'
         if sas_token is not None:
-            blob_uri += '?{sas_token}'
+            blob_uri += f'?{sas_token}'
         return blob_uri

--- a/sas_blob_utils.py
+++ b/sas_blob_utils.py
@@ -1,82 +1,81 @@
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License.
-import uuid
-import io
-from datetime import datetime, timedelta
-from urllib import parse
-
-from tqdm import tqdm
-from azure.storage.blob import (
-    BlockBlobService,
-    ContainerPermissions,
-    BlobPermissions,
-    PublicAccess,
-    ContentSettings,
-    BlobBlock,
-    BlockListType,
-)
-
-
 """
-This module contains helper functions for dealing with Shared Access Signatures (SAS) tokens
-for Azure Blob Storage.
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+
+This module contains helper functions for dealing with Shared Access Signatures
+(SAS) tokens for Azure Blob Storage.
 
 Documentation for Azure Blob Storage:
-https://azure-storage.readthedocs.io/ref/azure.storage.blob.baseblobservice.html
-https://azure-storage.readthedocs.io/ref/azure.storage.blob.blockblobservice.html
+https://docs.microsoft.com/en-us/azure/developer/python/sdk/storage/storage-blob-readme
 
 Documentation for SAS:
-https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1
+https://docs.microsoft.com/en-us/azure/storage/common/storage-sas-overview
 """
+from datetime import datetime, timedelta
+import io
+from typing import (
+    Any, AnyStr, Dict, IO, Iterable, List, Optional, Set, Tuple, Union)
+from urllib import parse
+import uuid
+
+from tqdm import tqdm
+
+from azure.storage.blob import (
+    BlobClient,
+    BlobProperties,
+    ContainerClient,
+    ContainerSasPermissions,
+    generate_container_sas,
+    upload_blob_to_url)
+from azure.core.exceptions import ResourceNotFoundError
+
 
 class SasBlob:
+    """SAS URI: https://<account>.blob.windows.net/<container>?<sas_token>"""
     @staticmethod
-    def _get_resource_reference(prefix):
+    def _get_resource_reference(prefix: str) -> str:
         return '{}{}'.format(prefix, str(uuid.uuid4()).replace('-', ''))
 
     @staticmethod
-    def get_service_from_uri(sas_uri):
-        return BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+    def get_client_from_uri(sas_uri: str) -> ContainerClient:
+        return ContainerClient.from_container_url(sas_uri)
 
     @staticmethod
-    def get_account_from_uri(sas_uri):
+    def get_account_from_uri(sas_uri: str) -> str:
         url_parts = parse.urlsplit(sas_uri)
-        loc = url_parts.netloc
+        loc = url_parts.netloc  # "<account>.blob.windows.net"
         return loc.split('.')[0]
 
     @staticmethod
-    def get_container_from_uri(sas_uri):
+    def get_container_from_uri(sas_uri: str) -> str:
         url_parts = parse.urlsplit(sas_uri)
-
-        raw_path = url_parts.path[1:]
+        raw_path = url_parts.path[1:]  # remove leading "/" from path
         container = raw_path.split('/')[0]
-
         return container
 
     @staticmethod
-    def get_blob_from_uri(sas_uri, unquote_blob=True):
-        """Return the path to the blob from the root container if this sas_uri is for an
-        individual blob; otherwise returns None.
+    def get_blob_from_uri(sas_uri: str, unquote_blob: bool = True
+                          ) -> Optional[str]:
+        """Return the path to the blob from the root container if this sas_uri
+        is for an individual blob; otherwise returns None.
 
         Args:
             sas_uri: Azure blob storage SAS token
-            unquote_blob: Replace any %xx escapes by their single-character equivalent. Default True.
+            unquote_blob: Replace any %xx escapes by their single-character
+                equivalent. Default True.
 
         Returns: Path to the blob from the root container or None.
-
         """
         # Get the entire path with all slashes after the container
         url_parts = parse.urlsplit(sas_uri)
-        raw_path = url_parts.path[1:]
+        raw_path = url_parts.path[1:]  # remove leading "/" from path
         container = raw_path.split('/')[0]
 
         parts = raw_path.split(container + '/')
         if len(parts) < 2:
             return None
 
-        blob = parts[1] # first item is an empty string
+        blob = parts[1]  # first item is an empty string
 
         if unquote_blob:
             blob = parse.unquote(blob)
@@ -84,21 +83,22 @@ class SasBlob:
         return blob
 
     @staticmethod
-    def get_sas_key_from_uri(sas_uri):
-        """Get the query part of the SAS token that contains permissions, access times and
-        signature.
+    def get_sas_key_from_uri(sas_uri: str) -> Optional[str]:
+        """Get the query part of the SAS token that contains permissions, access
+        times and signature.
 
         Args:
             sas_uri: Azure blob storage SAS token
 
-        Returns: Query part of the SAS token.
+        Returns: Query part of the SAS token, or None if URI has no token.
         """
         url_parts = parse.urlsplit(sas_uri)
-        return url_parts.query
+        sas_token = url_parts.query or None  # None if query is empty string
+        return sas_token
 
     @staticmethod
-    def get_resource_type_from_uri(sas_uri):
-        """Get the resource type pointed to by this SAS token
+    def get_resource_type_from_uri(sas_uri: str) -> Optional[str]:
+        """Get the resource type pointed to by this SAS token.
 
         Args:
             sas_uri: Azure blob storage SAS token
@@ -113,18 +113,17 @@ class SasBlob:
                 return 'blob'
             elif 'c' in types:
                 return 'container'
-        else:
-            return None
+        return None
 
     @staticmethod
-    def get_permissions_from_uri(sas_uri):
-        """Get the permissions given by this SAS token
+    def get_permissions_from_uri(sas_uri: str) -> Set[str]:
+        """Get the permissions given by this SAS token.
 
         Args:
             sas_uri: Azure blob storage SAS token
 
-        Returns: A set containing some of 'read', 'write', 'delete' and 'list'. Empty set
-        returned if no permission specified in sas_uri.
+        Returns: A set containing some of 'read', 'write', 'delete' and 'list'.
+            Empty set returned if no permission specified in sas_uri.
         """
         url_parts = parse.urlsplit(sas_uri)
         data = parse.parse_qs(url_parts.query)
@@ -142,153 +141,179 @@ class SasBlob:
         return permissions_set
 
     @staticmethod
-    def get_all_query_parts(sas_uri):
+    def get_all_query_parts(sas_uri: str) -> Dict[str, Any]:
+        """Gets the SAS token parameters."""
         url_parts = parse.urlsplit(sas_uri)
         return parse.parse_qs(url_parts.query)
 
     @staticmethod
-    def check_blob_existence(sas_uri, provided_blob_name=None):
-        if SasBlob.get_resource_type_from_uri(sas_uri) != 'blob':
-            raise ValueError('The SAS token provided is not for a blob.')
+    def check_blob_existence(sas_uri: str,
+                             provided_blob_name: Optional[str] = None) -> bool:
+        """Checks whether a given URI points to an actual blob.
 
-        if provided_blob_name:
-            blob_name = provided_blob_name
-        else:
-            blob_name = SasBlob.get_blob_from_uri(sas_uri)
-            if not blob_name:
-                raise ValueError('Blob name not provided as an argument, and also cannot be identified from the SAS token.')
+        Args:
+            sas_uri: str, URI to a container or a blob
+            provided_blob_name: optional str, name of blob
+                must be given if sas_uri is a URI to a container
+                overrides blob name in sas_uri if sas_uri is a URI to a blob
 
-        sas_service = BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+        Returns: bool, whether the sas_uri given points to an existing blob
+        """
+        blob_name = provided_blob_name or SasBlob.get_blob_from_uri(sas_uri)
+        if blob_name is None:
+            raise ValueError('Blob name not provided as an argument, and '
+                             'cannot be identified from the URI.')
 
-        container_name = SasBlob.get_container_from_uri(sas_uri)
-        return sas_service.exists(container_name, blob_name)
+        account = SasBlob.get_account_from_uri(sas_uri)
+        container = SasBlob.get_container_from_uri(sas_uri)
+        container_url = f'https://{account}.blob.windows.net/{container}'
+        container_client = ContainerClient.from_container_url(
+            container_url, credential=SasBlob.get_sas_key_from_uri(sas_uri))
+
+        # until Azure implements a proper BlobClient.exists() method, we can
+        # only use try/except to determine blob existence
+        # see: https://github.com/Azure/azure-sdk-for-python/issues/9507
+        blob_client = container_client.get_blob_client(blob_name)
+        try:
+            blob_client.get_blob_properties()
+        except ResourceNotFoundError:
+            return False
+        return True
 
     @staticmethod
-    def list_blobs_in_container(sas_uri, max_number_to_list, blob_prefix=None, blob_suffix=None):
-        """Get a list of blob names/paths in this container. This function will request a list of
-        4000 blobs at a time from the Blob Service (max number allowed is 5000), and use the
-        next_marker to retrieve more batches, until max_number_to_list is reached. If the
-        max_number_to_list is reached, a list containing that many results will be returned.
-
-        If you're processing the blob information one by one, get a generator and iterate using it instead.
+    def list_blobs_in_container(
+            sas_uri: str, max_number_to_list: int,
+            blob_prefix: Optional[str] = None,
+            blob_suffix: Optional[Union[str, Tuple[str]]] = None) -> List[str]:
+        """Get a list of blob names/paths in this container.
 
         Args:
             sas_uri: Azure blob storage SAS token
             max_number_to_list: Maximum number of blob names/paths to list
-            blob_prefix: Optional, a string as the prefix to blob names/paths to filter the results to those
-                        with this prefix
-            blob_suffix: Optional, a string or a tuple of strings, to filter the results to those with this/these
-                        suffix(s). The blob names will be lowercased first before comparing with the suffix(es).
+            blob_prefix: Optional, a string as the prefix to blob names/paths to
+                filter the results to those with this prefix
+            blob_suffix: Optional, a string or a tuple of strings, to filter the
+                results to those with this/these suffix(s). The blob names will
+                be lowercased first before comparing with the suffix(es).
+
         Returns:
-            A list of blob names/paths, of length max_number_to_list or shorter.
+            sorted list of blob names, of length max_number_to_list or shorter.
         """
         print('listing blobs...')
-        if SasBlob.get_resource_type_from_uri(sas_uri) != 'container':
+        if (SasBlob.get_sas_key_from_uri(sas_uri) is not None
+                and SasBlob.get_resource_type_from_uri(sas_uri) != 'container'):
             raise ValueError('The SAS token provided is not for a container.')
 
-        if blob_prefix and not isinstance(blob_prefix, str):
-            raise ValueError('blob_prefix needs to be a str.')
+        if blob_prefix is not None and not isinstance(blob_prefix, str):
+            raise ValueError('blob_prefix must be a str.')
 
-        if blob_suffix and not isinstance(blob_suffix, str) and not isinstance(blob_suffix, tuple):
-            raise ValueError('blob_suffix needs to be a str or a tuple of strings')
+        if (blob_suffix is not None
+                and not isinstance(blob_suffix, str)
+                and not isinstance(blob_suffix, tuple)):
+            raise ValueError('blob_suffix must be a str or a tuple of strings')
 
-        blob_service = SasBlob.get_service_from_uri(sas_uri)
-        container_name = SasBlob.get_container_from_uri(sas_uri)
-        generator = blob_service.list_blobs(container_name, prefix=blob_prefix, num_results=4000)
+        container_client = SasBlob.get_client_from_uri(sas_uri)
+        generator = container_client.list_blobs(name_starts_with=blob_prefix)
 
         list_blobs = []
 
         with tqdm() as pbar:
-            while True:
-                for blob in generator:
-                    if blob_suffix is None or blob.name.lower().endswith(blob_suffix):
-                        list_blobs.append(blob.name)
-                        pbar.update(1)
-
-                next_marker = generator.next_marker
-                if next_marker == '':
-                    # exhaustively listed all blobs in the container
-                    return list_blobs[:max_number_to_list]
-
-                if len(list_blobs) > max_number_to_list:
-                    return list_blobs[:max_number_to_list]
-
-                generator = blob_service.list_blobs(container_name, prefix=blob_prefix, num_results=4000,
-                                                    marker=next_marker)
-        # list_blobs will have been returned by one of the two stopping conditions
+            for blob in generator:
+                if blob_suffix is None or blob.name.lower().endswith(blob_suffix):
+                    list_blobs.append(blob.name)
+                    pbar.update(1)
+                    if len(list_blobs) == max_number_to_list:
+                        break
+        return sorted(list_blobs)  # sort for determinism
 
     @staticmethod
-    def generate_writable_container_sas(account_name, account_key, container_name, access_duration_hrs):
-        block_blob_service = BlockBlobService(account_name=account_name, account_key=account_key)
+    def generate_writable_container_sas(account_name: str,
+                                        account_key: str,
+                                        container_name: str,
+                                        access_duration_hrs: float) -> str:
+        """Creates a container and returns a SAS URI with read/write/list
+        permissions.
 
-        block_blob_service.create_container(container_name)
+        Args:
+            account_name: str, name of blob storage account
+            account_key: str, account SAS token or account shared access key
+            container_name: str, name of container to create, must not match an
+                existing container in the given storage account
+            access_duration_hrs: float
 
-        token = block_blob_service.generate_container_shared_access_signature(
-            container_name,
-            ContainerPermissions.WRITE + ContainerPermissions.READ + ContainerPermissions.LIST,
-            datetime.utcnow() + timedelta(hours=access_duration_hrs))
+        Returns: str, URL to newly created container
 
-        return block_blob_service.make_container_url(container_name=container_name, sas_token=token).replace(
-            "restype=container", "")
+        Raises: azure.core.exceptions.ResourceExistsError, if container already
+            exists
+        """
+        account_url = f'https://{account_name}.blob.windows.net'
+        container_client = ContainerClient(account_url=account_url,
+                                           container_name=container_name,
+                                           credential=account_key)
+        container_client.create_container()
 
-    @staticmethod
-    def create_blob_from_bytes(sas_uri, blob_name, input_bytes):
-        sas_service = BlockBlobService(
-            account_name = SasBlob.get_account_from_uri(sas_uri),
-            sas_token = SasBlob.get_sas_key_from_uri(sas_uri))
+        permissions = ContainerSasPermissions(read=True, write=True, list=True)
+        container_sas_token = generate_container_sas(
+            account_name=account_name,
+            container_name=container_name,
+            account_key=account_key,
+            permission=permissions,
+            expiry=datetime.utcnow() + timedelta(hours=access_duration_hrs))
 
-        container_name = SasBlob.get_container_from_uri(sas_uri)
-
-        sas_service.create_blob_from_bytes(container_name, blob_name, input_bytes)
-
-        return sas_service.make_blob_url(container_name, blob_name, sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
-
-    @staticmethod
-    def create_blob_from_text(sas_uri, blob_name, text):
-        sas_service = BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
-
-        container_name = SasBlob.get_container_from_uri(sas_uri)
-
-        sas_service.create_blob_from_text(container_name, blob_name, text, 'utf-8')
-
-        return sas_service.make_blob_url(container_name, blob_name, sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+        return f'{account_url}/{container_name}?{container_sas_token}'
 
     @staticmethod
-    def create_blob_from_stream(sas_uri, blob_name, input_stream):
-        sas_service = BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+    def upload_blob(container_sas_uri: str, blob_name: str,
+                    data: Union[Iterable[AnyStr], IO[AnyStr]]) -> str:
+        """Creates a new blob of the given name from an IO stream.
 
-        container_name = SasBlob.get_container_from_uri(sas_uri)
+        Args:
+            container_sas_uri: str, URI to a container
+            blob_name: str, name of blob to upload
+            data: str, bytes, or IO stream
+                if str, assumes utf-8 encoding
 
-        sas_service.create_blob_from_stream(container_name, blob_name, input_stream)
-
-        return sas_service.make_blob_url(container_name, blob_name, sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+        Returns: str, URI to blob
+        """
+        blob_url = SasBlob.generate_blob_sas_uri(container_sas_uri, blob_name)
+        upload_blob_to_url(blob_url, data=data)
+        return blob_url
 
     @staticmethod
-    def get_blob_to_stream(sas_uri):
-        sas_service = BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(sas_uri))
+    def get_blob_to_stream(sas_uri: str) -> Tuple[io.BytesIO, BlobProperties]:
+        """Downloads a blob to an IO stream.
 
+        Args:
+            sas_uri: str, URI to a blob
+
+        Returns:
+            output_stream: io.BytesIO
+            blob_properties: BlobProperties
+
+        Raises: azure.core.exceptions.ResourceNotFoundError, if sas_uri points
+            to a non-existant blob
+        """
+        blob_client = BlobClient.from_blob_url(sas_uri)
         with io.BytesIO() as output_stream:
-            blob = sas_service.get_blob_to_stream(SasBlob.get_container_from_uri(sas_uri),
-                                                  SasBlob.get_blob_from_uri(sas_uri),
-                                                  output_stream)
-        return output_stream, blob
+            blob_client.download_blob().readinto(output_stream)
+        blob_properties = blob_client.get_blob_properties()
+        return output_stream, blob_properties
 
     @staticmethod
-    def generate_blob_sas_uri(container_sas_uri, blob_name, create_if_not_exists=False):
+    def generate_blob_sas_uri(container_sas_uri: str, blob_name: str) -> str:
+        """
+        Args:
+            container_sas_uri: str, URI to blob storage container
+            blob_name: str, name of blob
+
+        Returns: str, blob URI
+        """
+        account_name = SasBlob.get_account_from_uri(container_sas_uri)
         container_name = SasBlob.get_container_from_uri(container_sas_uri)
-        sas_service = BlockBlobService(
-            account_name=SasBlob.get_account_from_uri(container_sas_uri),
-            sas_token=SasBlob.get_sas_key_from_uri(container_sas_uri))
-        blob_uri = sas_service.make_blob_url(container_name, blob_name,
-                                             sas_token=SasBlob.get_sas_key_from_uri(container_sas_uri))
+        sas_token = SasBlob.get_sas_key_from_uri(container_sas_uri)
 
+        account_url = f'https://{account_name}.blob.windows.net'
+        blob_uri = f'{account_url}/{container_name}/{blob_name}'
+        if sas_token is not None:
+            blob_uri += '?{sas_token}'
         return blob_uri
-

--- a/sas_blob_utils.py
+++ b/sas_blob_utils.py
@@ -5,6 +5,8 @@ Licensed under the MIT License.
 This module contains helper functions for dealing with Shared Access Signatures
 (SAS) tokens for Azure Blob Storage.
 
+This module assumes azure-storage-blob version 12.3.
+
 Documentation for Azure Blob Storage:
 https://docs.microsoft.com/en-us/azure/developer/python/sdk/storage/storage-blob-readme
 
@@ -38,48 +40,70 @@ class SasBlob:
 
     @staticmethod
     def get_client_from_uri(sas_uri: str) -> ContainerClient:
+        """Gets a ContainerClient for the given container URI."""
         return ContainerClient.from_container_url(sas_uri)
 
     @staticmethod
     def get_account_from_uri(sas_uri: str) -> str:
+        """
+        Assumes that sas_uri points to Azure Blob Storage account hosted at
+        a default Azure URI. Does not work for locally-emulated Azure Storage
+        or Azure Storage hosted at custom endpoints.
+        """
         url_parts = parse.urlsplit(sas_uri)
         loc = url_parts.netloc  # "<account>.blob.windows.net"
         return loc.split('.')[0]
 
     @staticmethod
-    def get_container_from_uri(sas_uri: str) -> str:
+    def get_container_from_uri(sas_uri: str, unquote: bool = True) -> str:
+        """Gets the container name from a Azure Blob Storage URI.
+
+        Assumes that sas_uri points to Azure Blob Storage account hosted at
+        a default Azure URI. Does not work for locally-emulated Azure Storage
+        or Azure Storage hosted at custom endpoints.
+
+        Args:
+            sas_uri: str, Azure blob storage URI, may include SAS token
+            unquote: bool, whether to replace any %xx escapes by their
+                single-character equivalent, default True
+
+        Returns: str, container name
+
+        Raises: ValueError, if sas_uri does not include a container
+        """
         url_parts = parse.urlsplit(sas_uri)
-        raw_path = url_parts.path[1:]  # remove leading "/" from path
+        raw_path = url_parts.path.lstrip('/')  # remove leading "/" from path
         container = raw_path.split('/')[0]
+        if container == '':
+            raise ValueError('Given sas_uri does not include a container.')
+        if unquote:
+            container = parse.unquote(container)
         return container
 
     @staticmethod
-    def get_blob_from_uri(sas_uri: str, unquote_blob: bool = True
-                          ) -> Optional[str]:
+    def get_blob_from_uri(sas_uri: str, unquote: bool = True) -> str:
         """Return the path to the blob from the root container if this sas_uri
         is for an individual blob; otherwise returns None.
 
         Args:
-            sas_uri: Azure blob storage SAS token
-            unquote_blob: Replace any %xx escapes by their single-character
-                equivalent. Default True.
+            sas_uri: str, Azure blob storage URI, may include SAS token
+            unquote: bool, whether to replace any %xx escapes by their
+                single-character equivalent, default True
 
-        Returns: Path to the blob from the root container or None.
+        Returns: str, blob name (path to the blob from the root container)
+
+        Raises: ValueError, if sas_uri does not include a blob name
         """
         # Get the entire path with all slashes after the container
         url_parts = parse.urlsplit(sas_uri)
-        raw_path = url_parts.path[1:]  # remove leading "/" from path
-        container = raw_path.split('/')[0]
-
-        parts = raw_path.split(container + '/')
-        if len(parts) < 2:
-            return None
+        raw_path = url_parts.path.lstrip('/')  # remove leading "/" from path
+        parts = raw_path.split('/', maxsplit=1)
+        if len(parts) < 2 or parts[1] == '':
+            raise ValueError('Given sas_uri does not include a blob name')
 
         blob = parts[1]  # first item is an empty string
-
-        if unquote_blob:
+        if unquote:
             blob = parse.unquote(blob)
-
         return blob
 
     @staticmethod
@@ -88,7 +112,7 @@ class SasBlob:
         times and signature.
 
         Args:
-            sas_uri: Azure blob storage SAS token
+            sas_uri: str, Azure blob storage SAS token
 
         Returns: Query part of the SAS token, or None if URI has no token.
         """
@@ -101,7 +125,7 @@ class SasBlob:
         """Get the resource type pointed to by this SAS token.
 
         Args:
-            sas_uri: Azure blob storage SAS token
+            sas_uri: str, Azure blob storage SAS token
 
         Returns: A string (either 'blob' or 'container') or None.
         """
@@ -120,7 +144,7 @@ class SasBlob:
         """Get the permissions given by this SAS token.
 
         Args:
-            sas_uri: Azure blob storage SAS token
+            sas_uri: str, Azure blob storage SAS token
 
         Returns: A set containing some of 'read', 'write', 'delete' and 'list'.
             Empty set returned if no permission specified in sas_uri.
@@ -148,56 +172,57 @@ class SasBlob:
 
     @staticmethod
     def check_blob_existence(sas_uri: str,
-                             provided_blob_name: Optional[str] = None) -> bool:
+                             blob_name: Optional[str] = None) -> bool:
         """Checks whether a given URI points to an actual blob.
 
         Args:
             sas_uri: str, URI to a container or a blob
-            provided_blob_name: optional str, name of blob
+            blob_name: optional str, name of blob
                 must be given if sas_uri is a URI to a container
                 overrides blob name in sas_uri if sas_uri is a URI to a blob
 
         Returns: bool, whether the sas_uri given points to an existing blob
         """
-        blob_name = provided_blob_name or SasBlob.get_blob_from_uri(sas_uri)
-        if blob_name is None:
-            raise ValueError('Blob name not provided as an argument, and '
-                             'cannot be identified from the URI.')
-
-        account = SasBlob.get_account_from_uri(sas_uri)
-        container = SasBlob.get_container_from_uri(sas_uri)
-        container_url = f'https://{account}.blob.core.windows.net/{container}'
-        container_client = ContainerClient.from_container_url(
-            container_url, credential=SasBlob.get_sas_key_from_uri(sas_uri))
+        if blob_name is not None:
+            account = SasBlob.get_account_from_uri(sas_uri)
+            container = SasBlob.get_container_from_uri(sas_uri)
+            sas_token = SasBlob.get_sas_key_from_uri(sas_uri)
+            container_url = f'https://{account}.blob.core.windows.net/{container}'
+            if sas_token is not None:
+                container_url += f'?{sas_token}'
+            sas_uri = SasBlob.generate_blob_sas_uri(
+                container_url, blob_name=blob_name)
 
         # until Azure implements a proper BlobClient.exists() method, we can
         # only use try/except to determine blob existence
         # see: https://github.com/Azure/azure-sdk-for-python/issues/9507
-        blob_client = container_client.get_blob_client(blob_name)
-        try:
-            blob_client.get_blob_properties()
-        except ResourceNotFoundError:
-            return False
-        return True
+        with BlobClient.from_blob_url(sas_uri) as blob_client:
+            try:
+                blob_client.get_blob_properties()
+            except ResourceNotFoundError:
+                return False
+            return True
 
     @staticmethod
     def list_blobs_in_container(
-            sas_uri: str, max_number_to_list: int,
+            sas_uri: str,
+            limit: Optional[int] = None,
             blob_prefix: Optional[str] = None,
             blob_suffix: Optional[Union[str, Tuple[str]]] = None) -> List[str]:
-        """Get a list of blob names/paths in this container.
+        """Get a list of blob names in this container.
 
         Args:
-            sas_uri: Azure blob storage SAS token
-            max_number_to_list: Maximum number of blob names/paths to list
-            blob_prefix: Optional, a string as the prefix to blob names/paths to
+            sas_uri: str, Azure blob storage SAS token
+            limit: int, maximum # of blob names to list
+                if None, then returns all blob names
+            blob_prefix: Optional, a string as the prefix to blob names to
                 filter the results to those with this prefix
             blob_suffix: Optional, a string or a tuple of strings, to filter the
                 results to those with this/these suffix(s). The blob names will
                 be lowercased first before comparing with the suffix(es).
 
         Returns:
-            sorted list of blob names, of length max_number_to_list or shorter.
+            sorted list of blob names, of length limit or shorter.
         """
         print('listing blobs...')
         if (SasBlob.get_sas_key_from_uri(sas_uri) is not None
@@ -212,17 +237,14 @@ class SasBlob:
                 and not isinstance(blob_suffix, tuple)):
             raise ValueError('blob_suffix must be a str or a tuple of strings')
 
-        container_client = SasBlob.get_client_from_uri(sas_uri)
-        generator = container_client.list_blobs(name_starts_with=blob_prefix)
-
         list_blobs = []
+        with SasBlob.get_client_from_uri(sas_uri) as container_client:
+            generator = container_client.list_blobs(name_starts_with=blob_prefix)
 
-        with tqdm() as pbar:
-            for blob in generator:
+            for blob in tqdm(generator):
                 if blob_suffix is None or blob.name.lower().endswith(blob_suffix):
                     list_blobs.append(blob.name)
-                    pbar.update(1)
-                    if len(list_blobs) == max_number_to_list:
+                    if limit is not None and len(list_blobs) == limit:
                         break
         return sorted(list_blobs)  # sort for determinism
 
@@ -230,7 +252,9 @@ class SasBlob:
     def generate_writable_container_sas(account_name: str,
                                         account_key: str,
                                         container_name: str,
-                                        access_duration_hrs: float) -> str:
+                                        access_duration_hrs: float,
+                                        account_url: Optional[str] = None
+                                        ) -> str:
         """Creates a container and returns a SAS URI with read/write/list
         permissions.
 
@@ -240,13 +264,20 @@ class SasBlob:
             container_name: str, name of container to create, must not match an
                 existing container in the given storage account
             access_duration_hrs: float
+            account_url: str, optional, defaults to default Azure Storage URL
 
         Returns: str, URL to newly created container
 
         Raises: azure.core.exceptions.ResourceExistsError, if container already
             exists
+
+        NOTE: This method currently fails on non-default Azure Storage URLs. The
+        initializer for ContainerClient() assumes the default Azure Storage URL
+        format, which is a bug that has been reported here:
+            https://github.com/Azure/azure-sdk-for-python/issues/12568
         """
-        account_url = f'https://{account_name}.blob.core.windows.net'
+        if account_url is None:
+            account_url = f'https://{account_name}.blob.core.windows.net'
         container_client = ContainerClient(account_url=account_url,
                                            container_name=container_name,
                                            credential=account_key)
@@ -287,16 +318,21 @@ class SasBlob:
             sas_uri: str, URI to a blob
 
         Returns:
-            output_stream: io.BytesIO
+            output_stream: io.BytesIO, remember to close it when finished using
             blob_properties: BlobProperties
 
         Raises: azure.core.exceptions.ResourceNotFoundError, if sas_uri points
             to a non-existant blob
+
+        NOTE: the returned BlobProperties object may have incorrect values for
+        the blob name and container name. This is a bug which has been reported
+        here: https://github.com/Azure/azure-sdk-for-python/issues/12563
         """
-        blob_client = BlobClient.from_blob_url(sas_uri)
-        with io.BytesIO() as output_stream:
+        with BlobClient.from_blob_url(sas_uri) as blob_client:
+            output_stream = io.BytesIO()
             blob_client.download_blob().readinto(output_stream)
-        blob_properties = blob_client.get_blob_properties()
+            output_stream.seek(0)
+            blob_properties = blob_client.get_blob_properties()
         return output_stream, blob_properties
 
     @staticmethod
@@ -304,15 +340,15 @@ class SasBlob:
         """
         Args:
             container_sas_uri: str, URI to blob storage container
+                <account_url>/<container_name>?<sas_token>
             blob_name: str, name of blob
 
         Returns: str, blob URI
+            <account_url>/<container_name>/<blob_name>?<sas_token>
         """
-        account_name = SasBlob.get_account_from_uri(container_sas_uri)
-        container_name = SasBlob.get_container_from_uri(container_sas_uri)
+        account_container = container_sas_uri.split('?', maxsplit=1)[0]
+        account_url, container_name = account_container.rsplit('/', maxsplit=1)
         sas_token = SasBlob.get_sas_key_from_uri(container_sas_uri)
-
-        account_url = f'https://{account_name}.blob.core.windows.net'
         blob_uri = f'{account_url}/{container_name}/{blob_name}'
         if sas_token is not None:
             blob_uri += f'?{sas_token}'

--- a/sas_blob_utils_test.py
+++ b/sas_blob_utils_test.py
@@ -21,7 +21,8 @@ changed by the parameters --blobHost 1.2.3.4 --blobPort 5678.
     mkdir $HOME/tmp/azurite
     azurite-blob -l $HOME/tmp/azurite
 
-4) Now we can run this unit test:
+4) In a separate terminal, activate a virtual environment with the Azure Storage
+Python SDK v12, then run this unit test:
     python test_sas_blob_utils.py -v
 
 Azurite by default supports the following storage account:

--- a/sas_blob_utils_test.py
+++ b/sas_blob_utils_test.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for sas_blob_utils.py
+
+In order to test "uploading" blobs without exposing private SAS keys, we use
+the Azurite blob storage emulator instead. Instructions for installing:
+
+Azurite documentation:
+https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azurite
+https://github.com/azure/azurite
+
+1) Install nodejs. Many ways to do so, but perhaps the easiest is via conda:
+    conda create -n node -c conda-forge nodejs
+    conda activate node
+
+2) Install Azurite from npm. The -g option installs the package globally.
+    npm install -g azurite
+
+3) Run Azurite. The -l flag sets a temp folder where Azurite can store data to
+disk. By default, Azurite's blob service runs at 127.0.0.1:10000, which can be
+changed by the parameters --blobHost 1.2.3.4 --blobPort 5678.
+    mkdir $HOME/tmp/azurite
+    azurite-blob -l $HOME/tmp/azurite
+
+4) Now we can run this unit test:
+    python test_sas_blob_utils.py -v
+
+Azurite by default supports the following storage account:
+- Account name: devstoreaccount1
+- Account key: Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
+"""
+
+import unittest
+
+from azure.core.exceptions import HttpResponseError, ResourceNotFoundError
+
+from sas_blob_utils import BlobClient, ContainerClient, SasBlob
+
+
+PUBLIC_CONTAINER_URI = 'https://lilablobssc.blob.core.windows.net/nacti-unzipped'
+PUBLIC_CONTAINER_SAS = 'st=2020-01-01T00%3A00%3A00Z&se=2034-01-01T00%3A00%3A00Z&sp=rl&sv=2019-07-07&sr=c&sig=rsgUcvoniBu/Vjkjzubh6gliU3XGvpE2A30Y0XPW4Vc%3D'
+PUBLIC_CONTAINER_URI_WITH_SAS = f'{PUBLIC_CONTAINER_URI}?{PUBLIC_CONTAINER_SAS}'
+PUBLIC_BLOB_NAME = 'part0/sub000/2010_Unit150_Ivan097_img0003.jpg'
+PUBLIC_INVALID_BLOB_NAME = 'part0/sub000/2010_Unit150_Ivan000_img0003.jpg'
+PUBLIC_BLOB_URI = f'{PUBLIC_CONTAINER_URI}/{PUBLIC_BLOB_NAME}'
+PUBLIC_BLOB_URI_WITH_SAS = f'{PUBLIC_BLOB_URI}?{PUBLIC_CONTAINER_SAS}'
+PUBLIC_INVALID_BLOB_URI = f'{PUBLIC_CONTAINER_URI}/{PUBLIC_INVALID_BLOB_NAME}'
+
+PUBLIC_ZIPPED_CONTAINER_URI = 'https://lilablobssc.blob.core.windows.net/wcs'
+
+# Azurite defaults
+PRIVATE_ACCOUNT_NAME = 'devstoreaccount1'
+PRIVATE_ACCOUNT_KEY = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
+PRIVATE_ACCOUNT_URI = f'http://127.0.0.1:10000/{PRIVATE_ACCOUNT_NAME}'
+PRIVATE_CONTAINER_NAME = 'mycontainer'
+PRIVATE_CONTAINER_URI = f'{PRIVATE_ACCOUNT_URI}/{PRIVATE_CONTAINER_NAME}'
+PRIVATE_BLOB_NAME = 'successdir/successblob'
+PRIVATE_BLOB_URI = f'{PRIVATE_CONTAINER_URI}/{PRIVATE_BLOB_NAME}'
+
+
+class TestSasBlobUtils(unittest.TestCase):
+    needs_cleanup = False
+
+    def tearDown(self):
+        if self.needs_cleanup:
+            # cleanup: delete the private emulated container
+            print('running cleanup')
+
+            # until the private emulated account is able to work, skip cleanup
+            # with ContainerClient.from_container_url(
+            #         PRIVATE_CONTAINER_URI,
+            #         credential=PRIVATE_ACCOUNT_KEY) as cc:
+            #     try:
+            #         cc.get_container_properties()
+            #         cc.delete_container()
+            #     except ResourceNotFoundError:
+            #         pass
+
+            # if SasBlob.check_blob_existence(PRIVATE_BLOB_URI):
+            #     with BlobClient.from_blob_url(
+            #             PRIVATE_BLOB_URI,
+            #             credential=PRIVATE_ACCOUNT_KEY) as bc:
+            #         bc.delete_blob(delete_snapshots=True)
+        self.needs_cleanup = False
+
+    def test_get_account_from_uri(self):
+        self.assertEqual(
+            SasBlob.get_account_from_uri(PUBLIC_BLOB_URI),
+            'lilablobssc')
+
+    def test_get_container_from_uri(self):
+        self.assertEqual(
+            SasBlob.get_container_from_uri(PUBLIC_BLOB_URI),
+            'nacti-unzipped')
+
+    def test_get_blob_from_uri(self):
+        self.assertEqual(
+            SasBlob.get_blob_from_uri(PUBLIC_BLOB_URI),
+            PUBLIC_BLOB_NAME)
+        with self.assertRaises(ValueError):
+            SasBlob.get_blob_from_uri(PUBLIC_CONTAINER_URI)
+
+    def test_get_sas_key_from_uri(self):
+        self.assertIsNone(SasBlob.get_sas_key_from_uri(PUBLIC_CONTAINER_URI))
+        self.assertEqual(
+            SasBlob.get_sas_key_from_uri(PUBLIC_CONTAINER_URI_WITH_SAS),
+            PUBLIC_CONTAINER_SAS)
+
+    def test_check_blob_existence(self):
+        print('PUBLIC_BLOB_URI')
+        self.assertTrue(SasBlob.check_blob_existence(PUBLIC_BLOB_URI))
+        print('PUBLIC_CONTAINER_URI + PUBLIC_BLOB_NAME')
+        self.assertTrue(SasBlob.check_blob_existence(
+            PUBLIC_CONTAINER_URI, blob_name=PUBLIC_BLOB_NAME))
+
+        print('PUBLIC_CONTAINER_URI')
+        with self.assertRaises(IndexError):  
+            SasBlob.check_blob_existence(PUBLIC_CONTAINER_URI)
+        print('PUBLIC_INVALID_BLOB_URI')
+        self.assertFalse(SasBlob.check_blob_existence(PUBLIC_INVALID_BLOB_URI))
+
+        print('PRIVATE_BLOB_URI')
+        with self.assertRaises(HttpResponseError):
+            SasBlob.check_blob_existence(PRIVATE_BLOB_URI)
+
+    def test_list_blobs_in_container(self):
+        blobs_list = SasBlob.list_blobs_in_container(
+            PUBLIC_ZIPPED_CONTAINER_URI, limit=100)
+        expected = sorted([
+            'wcs_20200403_bboxes.json.zip', 'wcs_camera_traps.json.zip',
+            'wcs_camera_traps_00.zip', 'wcs_camera_traps_01.zip',
+            'wcs_camera_traps_02.zip', 'wcs_camera_traps_03.zip',
+            'wcs_camera_traps_04.zip', 'wcs_camera_traps_05.zip',
+            'wcs_camera_traps_06.zip', 'wcs_specieslist.csv',
+            'wcs_splits.json'])
+        self.assertEqual(blobs_list, expected)
+
+    def test_generate_writable_container_sas(self):
+        # until the private emulated account is able to work, skip this test
+        self.skipTest('skipping private account tests for now')
+
+        self.needs_cleanup = True
+        new_sas_uri = SasBlob.generate_writable_container_sas(
+            account_name=PRIVATE_ACCOUNT_NAME,
+            account_key=PRIVATE_ACCOUNT_KEY,
+            container_name=PRIVATE_CONTAINER_NAME,
+            access_duration_hrs=1,
+            account_url=PRIVATE_ACCOUNT_URI)
+        self.assertTrue(isinstance(new_sas_uri, str))
+        self.assertNotEqual(new_sas_uri, '')
+        self.assertEqual(len(SasBlob.list_blobs_in_container(new_sas_uri)), 0)
+
+    def test_upload_blob(self):
+        self.needs_cleanup = True
+        # uploading to a read-only public container without a SAS token yields
+        # ResourceNotFoundError('The specified resource does not exist.')
+        print('PUBLIC_CONTAINER_URI')
+        with self.assertRaises(ResourceNotFoundError):
+            SasBlob.upload_blob(PUBLIC_CONTAINER_URI,
+                                blob_name='failblob', data='fail')
+
+        # uploading to a public container with a read-only SAS token yields
+        # HttpResponseError('This request is not authorized to perform this '
+        #                   'operation using this permission.')
+        print('PUBLIC_CONTAINER_URI_WITH_SAS')
+        with self.assertRaises(HttpResponseError):
+            SasBlob.upload_blob(PUBLIC_CONTAINER_URI_WITH_SAS,
+                                blob_name='failblob', data='fail')
+
+        # uploading to a private container without a SAS token yields
+        # HttpResponseError('Server failed to authenticate the request. Make '
+        #                   'sure the value of the Authorization header is '
+        #                   'formed correctly including the signature.')
+        print('PRIVATE_CONTAINER_URI')
+        with self.assertRaises(HttpResponseError):
+            SasBlob.upload_blob(PRIVATE_CONTAINER_URI,
+                                blob_name=PRIVATE_BLOB_NAME, data='success')
+
+        # until the private emulated account is able to work, skip this test
+        # private_container_uri_with_sas = SasBlob.generate_writable_container_sas(
+        #     account_name=PRIVATE_ACCOUNT_NAME,
+        #     account_key=PRIVATE_ACCOUNT_KEY,
+        #     container_name=PRIVATE_CONTAINER_NAME,
+        #     access_duration_hrs=1,
+        #     account_url=PRIVATE_ACCOUNT_URI)
+        # blob_url = SasBlob.upload_blob(
+        #     private_container_uri_with_sas,
+        #     blob_name=PRIVATE_BLOB_NAME, data='success')
+        # self.assertEqual(blob_url, PRIVATE_BLOB_URI)
+
+    def test_get_blob_to_stream(self):
+        output, props = SasBlob.get_blob_to_stream(PUBLIC_BLOB_URI)
+        x = output.read()
+        self.assertEqual(len(x), 376645)
+        output.close()
+
+        # see https://github.com/Azure/azure-sdk-for-python/issues/12563
+        expected_properties = {
+            'size': 376645,
+            # 'name': PUBLIC_BLOB_NAME,
+            # 'container': 'nacti-unzipped'
+        }
+
+        for k, v in expected_properties.items():
+            self.assertEqual(props[k], v)
+
+    def test_generate_blob_sas_uri(self):
+        generated = SasBlob.generate_blob_sas_uri(
+            container_sas_uri=PUBLIC_CONTAINER_URI,
+            blob_name=PUBLIC_BLOB_NAME)
+        self.assertEqual(generated, PUBLIC_BLOB_URI)
+
+        generated = SasBlob.generate_blob_sas_uri(
+            container_sas_uri=PUBLIC_CONTAINER_URI_WITH_SAS,
+            blob_name=PUBLIC_BLOB_NAME)
+        self.assertEqual(generated, PUBLIC_BLOB_URI_WITH_SAS)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@Siyu: I updated sas_blob_utils to use the new Azure Blob Storage Python SDK v12.

There are several places where I changed functionality and/or the interface:

1) in `check_blob_existence()`, I removed the following check because it would unnecessarily raise an error on public Azure blobs such as:
  https://lilablobssc.blob.core.windows.net/nacti-unzipped/part0/sub000/2010_Unit150_Ivan097_img0003.jpg

```python
if SasBlob.get_resource_type_from_uri(sas_uri) != 'blob':
    raise ValueError('The SAS token provided is not for a blob.')
```

2) I replaced `create_blob_from_bytes()`, `create_blob_from_text()`, and `create_blob_from_stream()` with a single method `upload_blob()` because the new v12 API no longer distinguishes between the different upload types.

3) I renamed the 1st parameter of `generate_blob_sas_uri()` from `sas_uri` to `container_sas_uri`.

4) I sort the list of blob names from `list_blobs_in_container()` for determinism.


I manually tested each of the methods without issue:

```python
from sas_blob_utils import SasBlob

from azure.core.exceptions import HttpResponseError


PUBLIC_BLOB_URI = 'https://lilablobssc.blob.core.windows.net/nacti-unzipped/part0/sub000/2010_Unit150_Ivan097_img0003.jpg'
PUBLIC_CONTAINER_URI = 'https://lilablobssc.blob.core.windows.net/nacti-unzipped'
ANOTHER_PUBLIC_CONTAINER_URI = 'https://lilablobssc.blob.core.windows.net/wcs'

CONTAINER_SAS = 'st=2020-01-01T00%3A00%3A00Z&se=2034-01-01T00%3A00%3A00Z&sp=rl&sv=2019-07-07&sr=c&sig=rsgUcvoniBu/Vjkjzubh6gliU3XGvpE2A30Y0XPW4Vc%3D'
PUBLIC_CONTAINER_URI_WITH_SAS = PUBLIC_CONTAINER_URI + '?' + CONTAINER_SAS

PRIVATE_BLOB_URI = **
PRIVATE_CONTAINER_SAS = **
PRIVATE_BLOB_URI_WITH_SAS = PRIVATE_BLOB_URI + '?' + PRIVATE_CONTAINER_SAS

INVALID_BLOB_URI = "https://lilablobssc.blob.core.windows.net/nacti-unzipped/part0/sub000/2010_Unit150_Ivan000_img0003.jpg"

PRIVATE_ACCOUNT_NAME = **
PRIVATE_ACCOUNT_SAS = **
PRIVATE_UPLOAD_CONTAINER_URI = **
PRIVATE_UPLOAD_CONTAINER_SAS = **
PRIVATE_UPLOAD_CONTAINER_URI_WITH_SAS = PRIVATE_UPLOAD_CONTAINER_URI + '?' + PRIVATE_UPLOAD_CONTAINER_SAS


def test_get_account_from_uri():
    print('test_get_account_from_uri')
    assert SasBlob.get_account_from_uri(PUBLIC_BLOB_URI) == 'lilablobssc'


def test_get_container_from_uri():
    print('test_get_container_from_uri')
    assert SasBlob.get_container_from_uri(PUBLIC_BLOB_URI) == 'nacti-unzipped'


def test_get_blob_from_uri():
    print('test_get_blob_from_uri')
    expected_blobname = 'part0/sub000/2010_Unit150_Ivan097_img0003.jpg'
    assert SasBlob.get_blob_from_uri(PUBLIC_BLOB_URI) == expected_blobname

    assert SasBlob.get_blob_from_uri(PUBLIC_CONTAINER_URI) is None


def test_get_sas_key_from_uri():
    print('test_get_sas_key_from_uri')
    assert SasBlob.get_sas_key_from_uri(PUBLIC_CONTAINER_URI) is None
    assert SasBlob.get_sas_key_from_uri(PUBLIC_CONTAINER_URI_WITH_SAS) == CONTAINER_SAS


def test_check_blob_existence():
    print('test_check_blob_existence')
    print('- PUBLIC_BLOB_URI...')
    assert SasBlob.check_blob_existence(PUBLIC_BLOB_URI) == True

    print('- PRIVATE_BLOB_URI...')
    assert SasBlob.check_blob_existence(PRIVATE_BLOB_URI) == False
    print('- PUBLIC_CONTAINER_URI...')
    try:
        SasBlob.check_blob_existence(PUBLIC_CONTAINER_URI)
        assert False
    except ValueError:
        pass
    print('- PUBLIC_CONTAINER_URI with blob name...')
    assert SasBlob.check_blob_existence(
        PUBLIC_CONTAINER_URI,
        provided_blob_name='part0/sub000/2010_Unit150_Ivan097_img0003.jpg') == True
    print('- INVALID_BLOB_URI...')
    assert SasBlob.check_blob_existence(INVALID_BLOB_URI) == False


def test_list_blobs_in_container():
    print('test_list_blobs_in_container')
    blobs_list = SasBlob.list_blobs_in_container(ANOTHER_PUBLIC_CONTAINER_URI,
        max_number_to_list=100)
    expected = sorted(['wcs_20200403_bboxes.json.zip', 'wcs_camera_traps.json.zip', 'wcs_camera_traps_00.zip', 'wcs_camera_traps_01.zip', 'wcs_camera_traps_02.zip', 'wcs_camera_traps_03.zip', 'wcs_camera_traps_04.zip', 'wcs_camera_traps_05.zip', 'wcs_camera_traps_06.zip', 'wcs_specieslist.csv', 'wcs_splits.json'])
    assert blobs_list == expected


def test_generate_writable_container_sas():
    new_sas_uri = SasBlob.generate_writable_container_sas(
        account_name=PRIVATE_ACCOUNT_NAME,
        account_key=PRIVATE_ACCOUNT_SAS,
        container_name='christest',
        access_duration_hrs=1)
    print(new_sas_uri)


def test_upload_blob():
    print('test_upload_blob')
    try:
        print('- testing upload to public container, should fail...')
        SasBlob.upload_blob(PUBLIC_CONTAINER_URI_WITH_SAS, 'failblob', data='fail')
        assert False
    except HttpResponseError:
        # HttpResponseError('This request is not authorized to perform this operation using this permission.')
        pass

    try:
        print('- testing upload to private container, should succeed...')
        blob_url = SasBlob.upload_blob(PRIVATE_UPLOAD_CONTAINER_URI_WITH_SAS, 'successblob', data='success')
        assert SasBlob.get_blob_from_uri(blob_url) == 'successblob'
    except Exception:
        assert False


def test_get_blob_to_stream():
    output, props = SasBlob.get_blob_to_stream(PRIVATE_BLOB_URI_WITH_SAS)
    print(props)
    return


if __name__ == '__main__':
    test_get_account_from_uri()
    test_get_container_from_uri()
    test_get_blob_from_uri()
    test_get_sas_key_from_uri()
    test_check_blob_existence()
    test_list_blobs_in_container()
    test_generate_writable_container_sas()
    test_upload_blob()
    test_get_blob_to_stream()
```