### PR TITLE
Add another example for gdal_rasterize. Mention rclone

### DIFF
--- a/geospatial/recipes_and_guides/geospatial_data_download_using_GEE.md
+++ b/geospatial/recipes_and_guides/geospatial_data_download_using_GEE.md
@@ -138,7 +138,7 @@ Map.addLayer(sentinel2_median_image, rgbVis, 'Sentinel RGB');
 
 #### Exporting Data to Google Drive
 
-You can export images, map tiles, tables and video from Earth Engine. The exports can be sent to your Google Drive account, to Google Cloud Storage or to a new Earth Engine asset. Read [here](https://developers.google.com/earth-engine/exporting) for more details.
+You can export images, map tiles, tables and video from Earth Engine. The exports can be sent to your Google Drive account, to Google Cloud Storage or to a new Earth Engine asset. Read [here](https://developers.google.com/earth-engine/exporting) for more details. [rclone](https://rclone.org/) is useful for programmatically downloading exported scenes from Google Drive.
 
 ```
 Export.image.toDrive({

--- a/geospatial/recipes_and_guides/geospatial_recipes.md
+++ b/geospatial/recipes_and_guides/geospatial_recipes.md
@@ -276,6 +276,13 @@ command = [
 subprocess.call(command)
 ```
 
+Another example for when you would like to specify an attribute field ("label" here) on the features to be used for a burn-in value:
+```
+gdal_rasterize -a label -a_nodata 0 -ot Byte -tr 0.000269494585236 0.000269494585236 
+```
+`tr` is the target resolution ("Pixel Size" in `gdalinfo` if you already have an example raster file of the desired resolution).
+
+
 ### Convert GeoTIFF to COG
 <a name="convert-geotiff-to-cog"></a>
 


### PR DESCRIPTION
for programmatically downloading data exported to gDrive.